### PR TITLE
fix: use relative paths for style.css and app.js in docs/index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@700&family=Cinzel:wght@400;500;700&family=IM+Fell+English:ital@1&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@700&family=Cinzel:wght@400;500;700&family=IM+Fell+English:ital@1&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="style.css">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -542,6 +542,6 @@
     </div>
   </div>
 
-  <script type="module" src="/app.js"></script>
+  <script type="module" src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The absolute paths (/style.css, /app.js) break on GitHub Pages where the site is served from a subdirectory (/Cartographer/). Changed to relative paths (style.css, app.js) so resources load correctly.

https://claude.ai/code/session_01FvwvUrD7ZG8tqQFB4f7FV2