### PR TITLE
fix: i18n section headings + template import coordinate mapping

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -120,40 +120,40 @@
     </div>
 
     <!-- 3. WORLDS SECTION -->
-    <section class="lp-section lp-worlds-section" id="worlds-section" aria-label="Vos mondes">
+    <section class="lp-section lp-worlds-section" id="worlds-section" data-i18n-aria="landing.worlds.ariaLabel" aria-label="Vos mondes">
       <div class="lp-section-header">
-        <svg class="lp-section-ornament" width="240" height="24" viewBox="0 0 240 24" role="img" aria-label="Ornement de section">
+        <svg class="lp-section-ornament" width="240" height="24" viewBox="0 0 240 24" role="img" data-i18n-aria="landing.worlds.ariaOrnament" aria-label="Ornement de section">
           <line x1="0" y1="12" x2="100" y2="12" stroke="#2E2416" stroke-width="1"/>
           <line x1="100" y1="12" x2="108" y2="12" stroke="#2E2416" stroke-width="0.5"/>
           <path d="M108,12 L114,6 L120,12 L114,18Z" fill="#2E2416"/>
           <line x1="120" y1="12" x2="128" y2="12" stroke="#2E2416" stroke-width="0.5"/>
           <line x1="128" y1="12" x2="240" y2="12" stroke="#2E2416" stroke-width="1"/>
         </svg>
-        <h2 class="lp-section-title">Vos mondes</h2>
-        <p class="lp-section-sub">Chaque monde, une aventure unique à cartographier</p>
+        <h2 class="lp-section-title" data-i18n="landing.worlds.title">Vos mondes</h2>
+        <p class="lp-section-sub" data-i18n="landing.worlds.sub">Chaque monde, une aventure unique à cartographier</p>
       </div>
       <div id="worlds-grid" class="lp-worlds-grid"></div>
     </section>
 
     <!-- 4. TEMPLATES -->
-    <section class="lp-section lp-templates-section" id="templates-section" aria-label="Templates">
+    <section class="lp-section lp-templates-section" id="templates-section" data-i18n-aria="landing.templates.ariaLabel" aria-label="Templates">
       <div class="lp-section-header">
-        <svg class="lp-section-ornament" width="240" height="24" viewBox="0 0 240 24" role="img" aria-label="Ornement de section">
+        <svg class="lp-section-ornament" width="240" height="24" viewBox="0 0 240 24" role="img" data-i18n-aria="landing.templates.ariaOrnament" aria-label="Ornement de section">
           <line x1="0" y1="12" x2="100" y2="12" stroke="#2E2416" stroke-width="1"/>
           <line x1="100" y1="12" x2="108" y2="12" stroke="#2E2416" stroke-width="0.5"/>
           <path d="M108,12 L114,6 L120,12 L114,18Z" fill="#2E2416"/>
           <line x1="120" y1="12" x2="128" y2="12" stroke="#2E2416" stroke-width="0.5"/>
           <line x1="128" y1="12" x2="240" y2="12" stroke="#2E2416" stroke-width="1"/>
         </svg>
-        <h2 class="lp-section-title">Partir d'un template</h2>
-        <p class="lp-section-sub">Cinq mondes prêts à explorer et modifier</p>
+        <h2 class="lp-section-title" data-i18n="landing.templates.title">Partir d'un template</h2>
+        <p class="lp-section-sub" data-i18n="landing.templates.sub">Cinq mondes prêts à explorer et modifier</p>
       </div>
       <div class="lp-carousel-wrapper">
-        <button class="lp-carousel-arrow lp-carousel-prev" aria-label="Défiler vers la gauche">
+        <button class="lp-carousel-arrow lp-carousel-prev" data-i18n-aria="landing.templates.ariaScrollLeft" aria-label="Défiler vers la gauche">
           <svg viewBox="0 0 24 24" width="20" height="20"><path d="M15 18l-6-6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </button>
         <div id="templates-grid" class="lp-templates-grid"></div>
-        <button class="lp-carousel-arrow lp-carousel-next" aria-label="Défiler vers la droite">
+        <button class="lp-carousel-arrow lp-carousel-next" data-i18n-aria="landing.templates.ariaScrollRight" aria-label="Défiler vers la droite">
           <svg viewBox="0 0 24 24" width="20" height="20"><path d="M9 18l6-6-6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </button>
       </div>

--- a/docs/ui/landing.js
+++ b/docs/ui/landing.js
@@ -126,9 +126,11 @@ export function initLandingAnimations() {
 
 // ─── Template import helpers ─────────────────────────────
 
-const VALID_ENTITY_TYPES = new Set(['territory', 'city', 'route', 'region', 'text', 'symbol']);
+const MAP_W = 1200, MAP_H = 800;
 const ENTITY_TYPE_MAP = { capital: 'city', village: 'city', fortress: 'city', ruins: 'symbol', lighthouse: 'symbol', port: 'city', town: 'city' };
 const TERRITORY_TYPE_MAP = { plains: 'territory', mountains: 'territory', swamp: 'region', ocean: 'territory', desert: 'territory', forest: 'region', tundra: 'territory', jungle: 'region' };
+const TERRAIN_TYPE_MAP = { plains: 'plains', mountains: 'mountain', swamp: 'swamp', desert: 'desert', ocean: 'ocean' };
+const REGION_TERRAIN_MAP = { swamp: 'swamp', forest: 'forest', jungle: 'forest', tundra: 'forest' };
 
 // ─── Template carousel ───────────────────────────────────
 
@@ -162,28 +164,64 @@ export function renderTemplates(app) {
       const lang = getLang();
       const resolveText = (val) => typeof val === 'object' && val !== null ? (val[lang] || val.fr || val.en || '') : (val || '');
 
+      // Build a lookup of entity positions (in world px) for route resolution
+      const entityPos = {};
+      for (const e of (tpl.entities || [])) {
+        if (e.x !== undefined) entityPos[e.id] = { x: e.x * MAP_W, y: e.y * MAP_H };
+      }
+
+      // Territories → territory or region entities
       const importEntities = [
-        ...(tpl.territories || []).map(ter => ({
-          id: ter.id,
-          type: TERRITORY_TYPE_MAP[ter.type] || 'territory',
-          name: ter.name || '',
-          data: { points: ter.points, color: ter.color, relief: ter.relief },
-        })),
+        ...(tpl.territories || []).map(ter => {
+          const dbType = TERRITORY_TYPE_MAP[ter.type] || 'territory';
+          const data = {
+            points: ter.points.map(p => ({ x: p.x * MAP_W, y: p.y * MAP_H })),
+            color: ter.color,
+          };
+          if (dbType === 'territory') {
+            data.terrainType = TERRAIN_TYPE_MAP[ter.type] || '';
+            data.terrainSeed = Math.floor(Math.random() * 100000);
+            data.terrainIntensity = Math.round((ter.relief?.intensity ?? 0.5) * 100);
+          } else {
+            data.terrain = REGION_TERRAIN_MAP[ter.type] || 'forest';
+          }
+          return { id: ter.id, type: dbType, name: ter.name || '', data };
+        }),
+
+        // Point entities → city or symbol
         ...(tpl.entities || []).map(e => {
-          const { id, type, name, description, ...rest } = e;
+          const dbType = ENTITY_TYPE_MAP[e.type] || e.type;
+          const data = {
+            x: e.x * MAP_W,
+            y: e.y * MAP_H,
+            importance: e.importance || 'village',
+            color: '#2C1810',
+            labelOffsetX: 12,
+            labelOffsetY: -8,
+            population: e.population || 0,
+            description: resolveText(e.description),
+          };
+          return { id: e.id, type: dbType, name: e.name || '', data };
+        }),
+
+        // Routes → resolved from entity positions
+        ...(tpl.routes || []).map((r, i) => {
+          const p1 = entityPos[r.from] || { x: MAP_W / 2, y: MAP_H / 2 };
+          const p2 = entityPos[r.to] || { x: MAP_W / 2, y: MAP_H / 2 };
+          const mx = (p1.x + p2.x) / 2, my = (p1.y + p2.y) / 2;
+          const dx = p2.x - p1.x, dy = p2.y - p1.y;
           return {
-            id,
-            type: VALID_ENTITY_TYPES.has(type) ? type : (ENTITY_TYPE_MAP[type] || 'symbol'),
-            name: name || '',
-            data: rest,
+            id: `route_${i}`,
+            type: 'route',
+            name: '',
+            data: {
+              x1: p1.x, y1: p1.y, x2: p2.x, y2: p2.y,
+              cx1: mx - dy * 0.15, cy1: my + dx * 0.15,
+              cx2: mx + dy * 0.15, cy2: my - dx * 0.15,
+              style: r.type || 'road',
+            },
           };
         }),
-        ...(tpl.routes || []).map((r, i) => ({
-          id: `route_${i}`,
-          type: 'route',
-          name: '',
-          data: { from: r.from, to: r.to, routeType: r.type },
-        })),
       ];
 
       const importEvents = (tpl.timeline || []).map(ev => ({

--- a/public/index.html
+++ b/public/index.html
@@ -120,40 +120,40 @@
     </div>
 
     <!-- 3. WORLDS SECTION -->
-    <section class="lp-section lp-worlds-section" id="worlds-section" aria-label="Vos mondes">
+    <section class="lp-section lp-worlds-section" id="worlds-section" data-i18n-aria="landing.worlds.ariaLabel" aria-label="Vos mondes">
       <div class="lp-section-header">
-        <svg class="lp-section-ornament" width="240" height="24" viewBox="0 0 240 24" role="img" aria-label="Ornement de section">
+        <svg class="lp-section-ornament" width="240" height="24" viewBox="0 0 240 24" role="img" data-i18n-aria="landing.worlds.ariaOrnament" aria-label="Ornement de section">
           <line x1="0" y1="12" x2="100" y2="12" stroke="#2E2416" stroke-width="1"/>
           <line x1="100" y1="12" x2="108" y2="12" stroke="#2E2416" stroke-width="0.5"/>
           <path d="M108,12 L114,6 L120,12 L114,18Z" fill="#2E2416"/>
           <line x1="120" y1="12" x2="128" y2="12" stroke="#2E2416" stroke-width="0.5"/>
           <line x1="128" y1="12" x2="240" y2="12" stroke="#2E2416" stroke-width="1"/>
         </svg>
-        <h2 class="lp-section-title">Vos mondes</h2>
-        <p class="lp-section-sub">Chaque monde, une aventure unique à cartographier</p>
+        <h2 class="lp-section-title" data-i18n="landing.worlds.title">Vos mondes</h2>
+        <p class="lp-section-sub" data-i18n="landing.worlds.sub">Chaque monde, une aventure unique à cartographier</p>
       </div>
       <div id="worlds-grid" class="lp-worlds-grid"></div>
     </section>
 
     <!-- 4. TEMPLATES -->
-    <section class="lp-section lp-templates-section" id="templates-section" aria-label="Templates">
+    <section class="lp-section lp-templates-section" id="templates-section" data-i18n-aria="landing.templates.ariaLabel" aria-label="Templates">
       <div class="lp-section-header">
-        <svg class="lp-section-ornament" width="240" height="24" viewBox="0 0 240 24" role="img" aria-label="Ornement de section">
+        <svg class="lp-section-ornament" width="240" height="24" viewBox="0 0 240 24" role="img" data-i18n-aria="landing.templates.ariaOrnament" aria-label="Ornement de section">
           <line x1="0" y1="12" x2="100" y2="12" stroke="#2E2416" stroke-width="1"/>
           <line x1="100" y1="12" x2="108" y2="12" stroke="#2E2416" stroke-width="0.5"/>
           <path d="M108,12 L114,6 L120,12 L114,18Z" fill="#2E2416"/>
           <line x1="120" y1="12" x2="128" y2="12" stroke="#2E2416" stroke-width="0.5"/>
           <line x1="128" y1="12" x2="240" y2="12" stroke="#2E2416" stroke-width="1"/>
         </svg>
-        <h2 class="lp-section-title">Partir d'un template</h2>
-        <p class="lp-section-sub">Cinq mondes prêts à explorer et modifier</p>
+        <h2 class="lp-section-title" data-i18n="landing.templates.title">Partir d'un template</h2>
+        <p class="lp-section-sub" data-i18n="landing.templates.sub">Cinq mondes prêts à explorer et modifier</p>
       </div>
       <div class="lp-carousel-wrapper">
-        <button class="lp-carousel-arrow lp-carousel-prev" aria-label="Défiler vers la gauche">
+        <button class="lp-carousel-arrow lp-carousel-prev" data-i18n-aria="landing.templates.ariaScrollLeft" aria-label="Défiler vers la gauche">
           <svg viewBox="0 0 24 24" width="20" height="20"><path d="M15 18l-6-6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </button>
         <div id="templates-grid" class="lp-templates-grid"></div>
-        <button class="lp-carousel-arrow lp-carousel-next" aria-label="Défiler vers la droite">
+        <button class="lp-carousel-arrow lp-carousel-next" data-i18n-aria="landing.templates.ariaScrollRight" aria-label="Défiler vers la droite">
           <svg viewBox="0 0 24 24" width="20" height="20"><path d="M9 18l6-6-6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </button>
       </div>

--- a/public/ui/landing.js
+++ b/public/ui/landing.js
@@ -126,9 +126,11 @@ export function initLandingAnimations() {
 
 // ─── Template import helpers ─────────────────────────────
 
-const VALID_ENTITY_TYPES = new Set(['territory', 'city', 'route', 'region', 'text', 'symbol']);
+const MAP_W = 1200, MAP_H = 800;
 const ENTITY_TYPE_MAP = { capital: 'city', village: 'city', fortress: 'city', ruins: 'symbol', lighthouse: 'symbol', port: 'city', town: 'city' };
 const TERRITORY_TYPE_MAP = { plains: 'territory', mountains: 'territory', swamp: 'region', ocean: 'territory', desert: 'territory', forest: 'region', tundra: 'territory', jungle: 'region' };
+const TERRAIN_TYPE_MAP = { plains: 'plains', mountains: 'mountain', swamp: 'swamp', desert: 'desert', ocean: 'ocean' };
+const REGION_TERRAIN_MAP = { swamp: 'swamp', forest: 'forest', jungle: 'forest', tundra: 'forest' };
 
 // ─── Template carousel ───────────────────────────────────
 
@@ -162,28 +164,64 @@ export function renderTemplates(app) {
       const lang = getLang();
       const resolveText = (val) => typeof val === 'object' && val !== null ? (val[lang] || val.fr || val.en || '') : (val || '');
 
+      // Build a lookup of entity positions (in world px) for route resolution
+      const entityPos = {};
+      for (const e of (tpl.entities || [])) {
+        if (e.x !== undefined) entityPos[e.id] = { x: e.x * MAP_W, y: e.y * MAP_H };
+      }
+
+      // Territories → territory or region entities
       const importEntities = [
-        ...(tpl.territories || []).map(ter => ({
-          id: ter.id,
-          type: TERRITORY_TYPE_MAP[ter.type] || 'territory',
-          name: ter.name || '',
-          data: { points: ter.points, color: ter.color, relief: ter.relief },
-        })),
+        ...(tpl.territories || []).map(ter => {
+          const dbType = TERRITORY_TYPE_MAP[ter.type] || 'territory';
+          const data = {
+            points: ter.points.map(p => ({ x: p.x * MAP_W, y: p.y * MAP_H })),
+            color: ter.color,
+          };
+          if (dbType === 'territory') {
+            data.terrainType = TERRAIN_TYPE_MAP[ter.type] || '';
+            data.terrainSeed = Math.floor(Math.random() * 100000);
+            data.terrainIntensity = Math.round((ter.relief?.intensity ?? 0.5) * 100);
+          } else {
+            data.terrain = REGION_TERRAIN_MAP[ter.type] || 'forest';
+          }
+          return { id: ter.id, type: dbType, name: ter.name || '', data };
+        }),
+
+        // Point entities → city or symbol
         ...(tpl.entities || []).map(e => {
-          const { id, type, name, description, ...rest } = e;
+          const dbType = ENTITY_TYPE_MAP[e.type] || e.type;
+          const data = {
+            x: e.x * MAP_W,
+            y: e.y * MAP_H,
+            importance: e.importance || 'village',
+            color: '#2C1810',
+            labelOffsetX: 12,
+            labelOffsetY: -8,
+            population: e.population || 0,
+            description: resolveText(e.description),
+          };
+          return { id: e.id, type: dbType, name: e.name || '', data };
+        }),
+
+        // Routes → resolved from entity positions
+        ...(tpl.routes || []).map((r, i) => {
+          const p1 = entityPos[r.from] || { x: MAP_W / 2, y: MAP_H / 2 };
+          const p2 = entityPos[r.to] || { x: MAP_W / 2, y: MAP_H / 2 };
+          const mx = (p1.x + p2.x) / 2, my = (p1.y + p2.y) / 2;
+          const dx = p2.x - p1.x, dy = p2.y - p1.y;
           return {
-            id,
-            type: VALID_ENTITY_TYPES.has(type) ? type : (ENTITY_TYPE_MAP[type] || 'symbol'),
-            name: name || '',
-            data: rest,
+            id: `route_${i}`,
+            type: 'route',
+            name: '',
+            data: {
+              x1: p1.x, y1: p1.y, x2: p2.x, y2: p2.y,
+              cx1: mx - dy * 0.15, cy1: my + dx * 0.15,
+              cx2: mx + dy * 0.15, cy2: my - dx * 0.15,
+              style: r.type || 'road',
+            },
           };
         }),
-        ...(tpl.routes || []).map((r, i) => ({
-          id: `route_${i}`,
-          type: 'route',
-          name: '',
-          data: { from: r.from, to: r.to, routeType: r.type },
-        })),
       ];
 
       const importEvents = (tpl.timeline || []).map(ev => ({


### PR DESCRIPTION
- Add data-i18n attributes to "Vos mondes" and "Partir d'un template" section headings, subtitles, aria-labels, and carousel arrows
- Fix template import: convert 0→1 proportional coordinates to world pixel coordinates (1200×800), add missing entity data fields (labelOffsetX/Y, terrainType, terrainSeed, etc.)
- Resolve route endpoints from entity positions instead of passing raw from/to IDs, compute Bézier control points
- Preserve docs/ relative path fixes (./style.css, ./app.js)

https://claude.ai/code/session_01FvwvUrD7ZG8tqQFB4f7FV2