### PR TITLE
fix: comprehensive fixes for entity placement, share, i18n, and curso…

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -156,9 +156,14 @@ const App = {
     initLandingAnimations();
 
     // Re-render dynamic sections on language switch
-    document.addEventListener('langchange', () => {
+    document.addEventListener('langchange', async () => {
       renderTemplates(this);
-      loadWorlds(this);
+      await loadWorlds(this);
+      // Cards are recreated with opacity:0 and need .visible to appear.
+      // Force-add .visible immediately since they are already in viewport.
+      document.querySelectorAll('.world-card, .world-card-new, .lp-tpl-card').forEach(c => {
+        c.classList.add('visible');
+      });
     });
 
     // Saved theme

--- a/docs/canvas/tools.js
+++ b/docs/canvas/tools.js
@@ -122,7 +122,9 @@ export const ToolsMixin = {
       btn.classList.toggle('active', btn.dataset.tool === tool);
     });
     const container = this.canvas.parentElement;
-    container.className = 'canvas-container cursor-' + tool;
+    // Remove any existing cursor-* class and set the new one
+    container.className = container.className.replace(/\bcursor-\S+/g, '').trim();
+    container.classList.add('cursor-' + tool);
     this._updateToolOptions();
     if (this.symbolLibrary) {
       if (tool === 'symbol') this.symbolLibrary.show();

--- a/docs/data/storage.js
+++ b/docs/data/storage.js
@@ -39,15 +39,23 @@ export async function api(method, url, body) {
   const worldExport = url.match(/^\/api\/worlds\/(\d+)\/export$/);
   if (worldExport) return LocalDB.exportWorld(Number(worldExport[1]));
 
-  // /api/worlds/:id/share  — sharing unsupported in static build
+  // /api/worlds/:id/share — generate a local share token stored in localStorage
   const worldShare = url.match(/^\/api\/worlds\/(\d+)\/share$/);
-  if (worldShare) throw new Error('Sharing is not available in the static demo');
+  if (worldShare) {
+    const worldId = Number(worldShare[1]);
+    return LocalDB.createShare(worldId, body);
+  }
+
+  // /api/worlds/:id/shares
+  const worldShares = url.match(/^\/api\/worlds\/(\d+)\/shares$/);
+  if (worldShares) return LocalDB.getShares(Number(worldShares[1]));
 
   // /api/worlds/:id
   const worldById = url.match(/^\/api\/worlds\/(\d+)$/);
   if (worldById) {
     const id = Number(worldById[1]);
     if (m === 'GET') return LocalDB.getWorld(id);
+    if (m === 'PUT') return LocalDB.updateWorld(id, body);
     if (m === 'DELETE') { LocalDB.deleteWorld(id); return {}; }
   }
 
@@ -59,7 +67,16 @@ export async function api(method, url, body) {
     if (m === 'DELETE') { LocalDB.deleteEntity(id); return {}; }
   }
 
-  throw new Error(`Unhandled static API: ${method} ${url}`);
+  // /api/events/:id
+  const eventById = url.match(/^\/api\/events\/(\d+)$/);
+  if (eventById) {
+    const id = Number(eventById[1]);
+    if (m === 'PUT') return LocalDB.updateEvent(id, body);
+    if (m === 'DELETE') { LocalDB.deleteEvent(id); return {}; }
+  }
+
+  console.warn(`Unhandled static API: ${method} ${url}`);
+  return {};
 }
 
 export function escapeHtml(str) {

--- a/docs/local-db.js
+++ b/docs/local-db.js
@@ -146,6 +146,32 @@ const LocalDB = {
     this._write('events', this._read('events').filter(e => e.id !== id));
   },
 
+  // ─── Shares ─────────────────────────────────────────────
+
+  createShare(worldId, opts) {
+    const shares = this._read('shares');
+    const token = Math.random().toString(36).slice(2, 14);
+    const expiresVal = opts && opts.expires;
+    let expiresAt = null;
+    if (expiresVal === '24h') expiresAt = new Date(Date.now() + 86400000).toISOString();
+    else if (expiresVal === '7d') expiresAt = new Date(Date.now() + 604800000).toISOString();
+    else if (expiresVal === '30d') expiresAt = new Date(Date.now() + 2592000000).toISOString();
+    const share = {
+      id: this._nextId('shares'),
+      token,
+      world_id: worldId,
+      expires_at: expiresAt,
+      created_at: new Date().toISOString(),
+    };
+    shares.push(share);
+    this._write('shares', shares);
+    return share;
+  },
+
+  getShares(worldId) {
+    return this._read('shares').filter(s => s.world_id === worldId);
+  },
+
   // ─── Import / Export ──────────────────────────────────────
 
   exportWorld(worldId) {

--- a/docs/style.css
+++ b/docs/style.css
@@ -1108,6 +1108,9 @@ a { color: var(--accent); }
 .cursor-symbol {
   cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpolygon points='12,3 14,10 21,10 16,14 18,21 12,17 6,21 8,14 3,10 10,10' fill='none' stroke='%232C1810' stroke-width='1.2'/%3E%3C/svg%3E") 12 12, crosshair;
 }
+.cursor-river {
+  cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M12 2c-1 4-4 6-4 10s2 6 0 10' fill='none' stroke='%232C1810' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E") 12 12, crosshair;
+}
 .cursor-grab { cursor: grab; }
 .cursor-grabbing { cursor: grabbing; }
 

--- a/docs/ui/editor.js
+++ b/docs/ui/editor.js
@@ -26,9 +26,9 @@ export async function openWorld(app) {
   if (!app.canvasEngine) {
     app.canvasEngine = new CanvasEngine(document.getElementById('main-canvas'));
     app.canvasEngine.onEntitySelected = (entity) => onEntitySelected(app, entity);
-    app.canvasEngine.onEntityCreated = (entity) => createEntity(app, entity);
-    app.canvasEngine.onEntityUpdated = (entity) => updateEntity(app, entity);
-    app.canvasEngine.onEntityDeleted = (entity) => deleteEntity(app, entity);
+    app.canvasEngine.onEntityCreated = (entity) => createEntity(app, entity).catch(err => { console.error('Entity creation failed:', err); showToast(err.message, 'error'); });
+    app.canvasEngine.onEntityUpdated = (entity) => updateEntity(app, entity).catch(err => { console.error('Entity update failed:', err); showToast(err.message, 'error'); });
+    app.canvasEngine.onEntityDeleted = (entity) => deleteEntity(app, entity).catch(err => { console.error('Entity delete failed:', err); showToast(err.message, 'error'); });
     app.canvasEngine.onEntityMoved = (entity, oldData) => moveEntityWithUndo(app, entity, oldData);
     app.canvasEngine.layersPanel = app.layersPanel;
 

--- a/public/app.js
+++ b/public/app.js
@@ -156,9 +156,14 @@ const App = {
     initLandingAnimations();
 
     // Re-render dynamic sections on language switch
-    document.addEventListener('langchange', () => {
+    document.addEventListener('langchange', async () => {
       renderTemplates(this);
-      loadWorlds(this);
+      await loadWorlds(this);
+      // Cards are recreated with opacity:0 and need .visible to appear.
+      // Force-add .visible immediately since they are already in viewport.
+      document.querySelectorAll('.world-card, .world-card-new, .lp-tpl-card').forEach(c => {
+        c.classList.add('visible');
+      });
     });
 
     // Saved theme

--- a/public/canvas/tools.js
+++ b/public/canvas/tools.js
@@ -122,7 +122,9 @@ export const ToolsMixin = {
       btn.classList.toggle('active', btn.dataset.tool === tool);
     });
     const container = this.canvas.parentElement;
-    container.className = 'canvas-container cursor-' + tool;
+    // Remove any existing cursor-* class and set the new one
+    container.className = container.className.replace(/\bcursor-\S+/g, '').trim();
+    container.classList.add('cursor-' + tool);
     this._updateToolOptions();
     if (this.symbolLibrary) {
       if (tool === 'symbol') this.symbolLibrary.show();

--- a/public/style.css
+++ b/public/style.css
@@ -1108,6 +1108,9 @@ a { color: var(--accent); }
 .cursor-symbol {
   cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpolygon points='12,3 14,10 21,10 16,14 18,21 12,17 6,21 8,14 3,10 10,10' fill='none' stroke='%232C1810' stroke-width='1.2'/%3E%3C/svg%3E") 12 12, crosshair;
 }
+.cursor-river {
+  cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M12 2c-1 4-4 6-4 10s2 6 0 10' fill='none' stroke='%232C1810' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E") 12 12, crosshair;
+}
 .cursor-grab { cursor: grab; }
 .cursor-grabbing { cursor: grabbing; }
 

--- a/public/ui/editor.js
+++ b/public/ui/editor.js
@@ -26,9 +26,9 @@ export async function openWorld(app) {
   if (!app.canvasEngine) {
     app.canvasEngine = new CanvasEngine(document.getElementById('main-canvas'));
     app.canvasEngine.onEntitySelected = (entity) => onEntitySelected(app, entity);
-    app.canvasEngine.onEntityCreated = (entity) => createEntity(app, entity);
-    app.canvasEngine.onEntityUpdated = (entity) => updateEntity(app, entity);
-    app.canvasEngine.onEntityDeleted = (entity) => deleteEntity(app, entity);
+    app.canvasEngine.onEntityCreated = (entity) => createEntity(app, entity).catch(err => { console.error('Entity creation failed:', err); showToast(err.message, 'error'); });
+    app.canvasEngine.onEntityUpdated = (entity) => updateEntity(app, entity).catch(err => { console.error('Entity update failed:', err); showToast(err.message, 'error'); });
+    app.canvasEngine.onEntityDeleted = (entity) => deleteEntity(app, entity).catch(err => { console.error('Entity delete failed:', err); showToast(err.message, 'error'); });
     app.canvasEngine.onEntityMoved = (entity, oldData) => moveEntityWithUndo(app, entity, oldData);
     app.canvasEngine.layersPanel = app.layersPanel;
 


### PR DESCRIPTION
…r bugs

1. Entity callbacks: add .catch() on all async canvas→editor callbacks (onEntityCreated, onEntityUpdated, onEntityDeleted) so errors surface via toast instead of silently failing

2. Storage shim (docs/): add missing routes — PUT /api/worlds/:id, PUT/DELETE /api/events/:id. Change unhandled routes from throwing to console.warn + return {} to avoid silent crashes

3. Share (docs/): implement local share via LocalDB.createShare() that generates a random token stored in localStorage, so the generate button actually works in the static demo

4. Language switching: await loadWorlds() in langchange handler, then force-add .visible class on all recreated cards so they appear immediately (cards have opacity:0 by default and rely on IntersectionObserver which may not re-trigger for already-visible elements)

5. Tool cursor: fix setTool() which was clobbering the container's className (replacing all classes with 'canvas-container cursor-X'). Now strips only cursor-* classes and adds the new one via classList. Add missing .cursor-river CSS class.

https://claude.ai/code/session_01FvwvUrD7ZG8tqQFB4f7FV2