### PR TITLE
fix: absolute paths /style.css and /app.js → relative ./

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@700&family=Cinzel:wght@400;500;700&family=IM+Fell+English:ital@1&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@700&family=Cinzel:wght@400;500;700&family=IM+Fell+English:ital@1&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="./style.css">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -549,6 +549,6 @@
     </div>
   </div>
 
-  <script type="module" src="/app.js"></script>
+  <script type="module" src="./app.js"></script>
 </body>
 </html>

--- a/docs/viewer.html
+++ b/docs/viewer.html
@@ -6,7 +6,7 @@
   <title>Cartographer — Shared Map</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="./style.css">
   <style>
     body { margin: 0; overflow: hidden; background: var(--bg); }
     .viewer-topbar {

--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@700&family=Cinzel:wght@400;500;700&family=IM+Fell+English:ital@1&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@700&family=Cinzel:wght@400;500;700&family=IM+Fell+English:ital@1&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="./style.css">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -549,6 +549,6 @@
     </div>
   </div>
 
-  <script type="module" src="/app.js"></script>
+  <script type="module" src="./app.js"></script>
 </body>
 </html>

--- a/public/viewer.html
+++ b/public/viewer.html
@@ -6,7 +6,7 @@
   <title>Cartographer — Shared Map</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="./style.css">
   <style>
     body { margin: 0; overflow: hidden; background: var(--bg); }
     .viewer-topbar {


### PR DESCRIPTION
Absolute paths break when served from a subdirectory or non-root context. Fixed in index.html (style.css + app.js) and viewer.html (style.css), both public/ and docs/.

https://claude.ai/code/session_01FvwvUrD7ZG8tqQFB4f7FV2