### PR TITLE
fix: remove old onboarding + fix empty state reappearing

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -16,7 +16,6 @@ import { UndoManager } from './undo.js';
 import { LayersPanel } from './layers.js';
 import { ThemeManager, MAP_THEMES } from './themes.js';
 import { ModeToggle } from './mode-toggle.js';
-import { Onboarding } from './onboarding.js';
 import { initI18n, t } from './i18n.js';
 
 // ─── Shared application state ────────────────────────────
@@ -118,9 +117,6 @@ const App = {
           this._tutorial.constructor.reset();
           this._tutorial.destroy();
           this._tutorial.start(0);
-        } else {
-          if (!this._onboarding) this._onboarding = new Onboarding();
-          this._onboarding.start(this.currentWorld.id);
         }
       }
     });

--- a/docs/ui/editor.js
+++ b/docs/ui/editor.js
@@ -9,7 +9,6 @@ import { CanvasEngine } from '../canvas/engine.js';
 import { SymbolLibrary } from '../symbols/index.js';
 import { SnapGuides } from '../snap.js';
 import { Minimap } from '../minimap.js';
-import { Onboarding } from '../onboarding.js';
 import { Tutorial } from './tutorial.js';
 import { SvgExportPanel } from '../svg-export.js';
 import { AddEntityCommand, DeleteEntityCommand, MoveEntityCommand, ModifyEntityCommand } from '../undo.js';
@@ -82,11 +81,6 @@ export async function openWorld(app) {
     app._hintSystem = new HintSystem(canvasContainer);
   }
   app._hintSystem.checkContext({ tool: app.canvasEngine.tool, entities: app.entities });
-
-  if (!app._onboarding) app._onboarding = new Onboarding();
-  if (app._onboarding.shouldShow(app.currentWorld.id)) {
-    setTimeout(() => app._onboarding.start(app.currentWorld.id), 500);
-  }
 
   if (!app._tutorial) app._tutorial = new Tutorial(app);
   if (app._tutorial.shouldStart() && !(app._emptyState && app._emptyState.visible)) {

--- a/docs/ui/empty-state.js
+++ b/docs/ui/empty-state.js
@@ -80,7 +80,7 @@ export class EmptyState {
   }
 
   check(entities) {
-    const has = entities && entities.some(e => e.type === 'territory');
+    const has = entities && entities.length > 0;
     if (has) this.hide(); else this.show();
   }
 

--- a/public/app.js
+++ b/public/app.js
@@ -16,7 +16,6 @@ import { UndoManager } from './undo.js';
 import { LayersPanel } from './layers.js';
 import { ThemeManager, MAP_THEMES } from './themes.js';
 import { ModeToggle } from './mode-toggle.js';
-import { Onboarding } from './onboarding.js';
 import { initI18n, t } from './i18n.js';
 
 // ─── Shared application state ────────────────────────────
@@ -118,9 +117,6 @@ const App = {
           this._tutorial.constructor.reset();
           this._tutorial.destroy();
           this._tutorial.start(0);
-        } else {
-          if (!this._onboarding) this._onboarding = new Onboarding();
-          this._onboarding.start(this.currentWorld.id);
         }
       }
     });

--- a/public/ui/editor.js
+++ b/public/ui/editor.js
@@ -9,7 +9,6 @@ import { CanvasEngine } from '../canvas/engine.js';
 import { SymbolLibrary } from '../symbols/index.js';
 import { SnapGuides } from '../snap.js';
 import { Minimap } from '../minimap.js';
-import { Onboarding } from '../onboarding.js';
 import { Tutorial } from './tutorial.js';
 import { SvgExportPanel } from '../svg-export.js';
 import { AddEntityCommand, DeleteEntityCommand, MoveEntityCommand, ModifyEntityCommand } from '../undo.js';
@@ -82,11 +81,6 @@ export async function openWorld(app) {
     app._hintSystem = new HintSystem(canvasContainer);
   }
   app._hintSystem.checkContext({ tool: app.canvasEngine.tool, entities: app.entities });
-
-  if (!app._onboarding) app._onboarding = new Onboarding();
-  if (app._onboarding.shouldShow(app.currentWorld.id)) {
-    setTimeout(() => app._onboarding.start(app.currentWorld.id), 500);
-  }
 
   if (!app._tutorial) app._tutorial = new Tutorial(app);
   if (app._tutorial.shouldStart() && !(app._emptyState && app._emptyState.visible)) {

--- a/public/ui/empty-state.js
+++ b/public/ui/empty-state.js
@@ -80,7 +80,7 @@ export class EmptyState {
   }
 
   check(entities) {
-    const has = entities && entities.some(e => e.type === 'territory');
+    const has = entities && entities.length > 0;
     if (has) this.hide(); else this.show();
   }
 


### PR DESCRIPTION
1. Removed legacy 6-step Onboarding that was launching alongside the new 8-step Tutorial on every world open (per-world localStorage key meant it showed for each new world).
2. Empty state check now looks at all entities (length > 0) instead of only territories, so worlds with cities/routes don't trigger it.

https://claude.ai/code/session_01FvwvUrD7ZG8tqQFB4f7FV2